### PR TITLE
Compile and commit project as a GitHub Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,6 @@ build/
 poetry.toml
 Pipfile
 merge-resolver.sh
+
+# Include ignored files during compilation process
+!.gitignore

--- a/Dockerfile.openpilot_base
+++ b/Dockerfile.openpilot_base
@@ -13,7 +13,8 @@ ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
 
 COPY tools/install_ubuntu_dependencies.sh /tmp/tools/
-RUN INSTALL_EXTRA_PACKAGES=no /tmp/tools/install_ubuntu_dependencies.sh && \
+RUN chmod +x /tmp/tools/install_ubuntu_dependencies.sh && \
+    INSTALL_EXTRA_PACKAGES=no /tmp/tools/install_ubuntu_dependencies.sh && \
     rm -rf /var/lib/apt/lists/* /tmp/* && \
     cd /usr/lib/gcc/arm-none-eabi/9.2.1 && \
     rm -rf arm/ thumb/nofp thumb/v6* thumb/v8* thumb/v7+fp thumb/v7-r+fp.sp

--- a/selfdrive/compile_and_commit.yaml
+++ b/selfdrive/compile_and_commit.yaml
@@ -1,0 +1,49 @@
+name: Compile and Commit
+
+on:
+  push:
+    branches:
+      - Chubbs
+  workflow_dispatch:
+
+jobs:
+  compile_and_commit:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Compile the project
+      run: scons -j$(nproc)
+
+    - name: Include ignored files
+      run: |
+        git add -f $(git ls-files --others --exclude-standard)
+
+    - name: Delete files that are deleted during compilation
+      run: |
+        git ls-files --deleted -z | xargs -0 git rm
+
+    - name: Commit and push changes
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git checkout -b compiled-project
+        git add .
+        git commit -m "Compiled project"
+        git push --set-upstream origin compiled-project


### PR DESCRIPTION
Add a GitHub Action workflow to compile the project and commit the compiled project as its own branch.

* **New GitHub Action Workflow**: Add `selfdrive/compile_and_commit.yaml` to handle the compilation and commit process.
  * Checkout repository, set up Python, install dependencies, compile the project, include ignored files, delete files that are deleted during compilation, and commit and push changes to a new branch named `compiled-project`.

* **.gitignore Update**: Modify `.gitignore` to include ignored files during the compilation process.
  * Add `!.gitignore` to ensure ignored files are included.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Discountchubbs/chubbspilot/pull/2?shareId=51940405-f7cc-4218-9037-87639a0322d5).